### PR TITLE
fix(ci): inject web3forms key in pages deploy build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,9 +21,13 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    environment:
+      name: github-pages
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
+    env:
+      PUBLIC_WEB3FORMS_ACCESS_KEY: ${{ secrets.PUBLIC_WEB3FORMS_ACCESS_KEY }}
 
     steps:
       - name: Checkout repository
@@ -37,6 +41,13 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Verify Web3Forms key is available
+        run: |
+          if [ -z "${PUBLIC_WEB3FORMS_ACCESS_KEY}" ]; then
+            echo "Error: PUBLIC_WEB3FORMS_ACCESS_KEY is not set for deploy build."
+            exit 1
+          fi
 
       - name: Build site
         run: npm run build

--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ The site is deployed to GitHub Pages via GitHub Actions:
 2. After CI passes, the deploy workflow builds the site
 3. Site is deployed to GitHub Pages
 
+`PUBLIC_WEB3FORMS_ACCESS_KEY` must be configured in the `github-pages` environment secrets so it is available during the deploy build job.
+
 Manual deployment is available via the Actions tab (`workflow_dispatch`), bypassing CI.
 
 ## License


### PR DESCRIPTION
## Summary

Expose `PUBLIC_WEB3FORMS_ACCESS_KEY` to the GitHub Pages deploy build so the static build has the expected public key, and fail fast when the key is missing.

Closes #34

## Changes

- Added `github-pages` environment to deploy `build` job in `.github/workflows/deploy.yml`
- Injected `PUBLIC_WEB3FORMS_ACCESS_KEY` into deploy build job env from `secrets`
- Added a safe pre-build guard step that fails if the key is unset
- Documented the required `github-pages` environment secret in `README.md`

## Test Plan

- [x] `npm run lint` passes
- [x] `npm run format:check` passes
- [x] `npm run build` succeeds
- [ ] E2E tests pass (Chromium via pre-push hook)
- [x] Manual validation completed

## Screenshots (if applicable)

N/A

---
Generated with Claude Code