### PR TITLE
feat(theme): improve light-mode CTA contrast and shimmer hover

### DIFF
--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -155,7 +155,7 @@ const currentPath = Astro.url.pathname.replace(languagePrefixRegex, '') || '/';
         <li class="ml-2">
           <a
             href={contactHref}
-            class="bg-gradient-primary text-primary-foreground hover:shadow-glow inline-flex h-10 items-center justify-center rounded-lg px-5 text-sm font-medium transition-all hover:scale-[1.02]"
+            class="bg-gradient-primary text-primary-foreground cta-primary hover:shadow-glow inline-flex h-10 items-center justify-center rounded-lg px-5 text-sm font-medium transition-all hover:scale-[1.02]"
           >
             {t.hero.cta}
           </a>
@@ -276,7 +276,7 @@ const currentPath = Astro.url.pathname.replace(languagePrefixRegex, '') || '/';
         <li class="mt-2">
           <a
             href={contactHref}
-            class="bg-gradient-primary text-primary-foreground hover:shadow-glow flex h-12 items-center justify-center rounded-lg text-base font-medium transition-all"
+            class="bg-gradient-primary text-primary-foreground cta-primary hover:shadow-glow flex h-12 items-center justify-center rounded-lg text-base font-medium transition-all"
           >
             {t.hero.cta}
           </a>

--- a/src/components/sections/CTASection.astro
+++ b/src/components/sections/CTASection.astro
@@ -39,7 +39,7 @@ const servicesHref = getLocalizedPath(lang, Route.Services);
         >
           <a
             href={contactHref}
-            class="bg-gradient-primary text-primary-foreground hover:shadow-glow inline-flex h-12 w-full items-center justify-center gap-2 rounded-lg px-8 text-base font-medium transition-all hover:scale-[1.02] sm:w-auto"
+            class="bg-gradient-primary text-primary-foreground cta-primary hover:shadow-glow inline-flex h-12 w-full items-center justify-center gap-2 rounded-lg px-8 text-base font-medium transition-all hover:scale-[1.02] sm:w-auto"
           >
             {t.hero.cta}
             <svg

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -22,7 +22,7 @@ const buttonVariants = cva(
     variants: {
       variant: {
         primary: [
-          'bg-gradient-primary text-primary-foreground',
+          'bg-gradient-primary text-primary-foreground cta-primary',
           'hover:shadow-glow hover:scale-[1.02]',
           'active:scale-[0.98]',
         ],

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -322,6 +322,58 @@ svg {
   );
 }
 
+/* Primary CTA button effects */
+@keyframes cta-shimmer {
+  from {
+    transform: translateX(-140%) skewX(-18deg);
+  }
+  to {
+    transform: translateX(140%) skewX(-18deg);
+  }
+}
+
+.cta-primary {
+  position: relative;
+  overflow: hidden;
+  isolation: isolate;
+  color: var(--color-primary-foreground);
+}
+
+[data-theme='light'] .cta-primary {
+  color: #ffffff;
+}
+
+.cta-primary::after {
+  content: '';
+  position: absolute;
+  inset: -120% -40%;
+  z-index: 0;
+  pointer-events: none;
+  opacity: 0;
+  background: linear-gradient(
+    115deg,
+    transparent 35%,
+    rgba(255, 255, 255, 0) 45%,
+    rgba(255, 255, 255, 0.28) 50%,
+    rgba(255, 255, 255, 0) 55%,
+    transparent 65%
+  );
+  transform: translateX(-140%) skewX(-18deg);
+}
+
+.cta-primary > * {
+  position: relative;
+  z-index: 1;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .cta-primary:hover::after,
+  .cta-primary:focus-visible::after {
+    opacity: 1;
+    animation: cta-shimmer 850ms var(--ease-out) 1;
+  }
+}
+
 .bg-gradient-secondary {
   background: linear-gradient(
     135deg,
@@ -622,5 +674,11 @@ svg {
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;
+  }
+
+  .cta-primary:hover::after,
+  .cta-primary:focus-visible::after {
+    opacity: 0 !important;
+    animation: none !important;
   }
 }

--- a/tests/theme.spec.ts
+++ b/tests/theme.spec.ts
@@ -239,6 +239,77 @@ test.describe('Theme System', () => {
     });
   });
 
+  test.describe('Primary CTA Styling', () => {
+    test('should render primary CTA buttons with white text in light theme', async ({
+      page,
+    }) => {
+      await page.setViewportSize({ width: 1280, height: 800 });
+      await page.emulateMedia({ colorScheme: 'light' });
+      await page.goto(Route.Home);
+
+      const primaryCta = page
+        .locator('a.cta-primary, button.cta-primary')
+        .first();
+      await expect(primaryCta).toBeVisible();
+
+      const color = await primaryCta.evaluate(
+        (el) => window.getComputedStyle(el).color
+      );
+
+      expect(color).toBe('rgb(255, 255, 255)');
+    });
+
+    test('should trigger subtle shimmer on hover for primary CTA buttons', async ({
+      page,
+    }) => {
+      await page.setViewportSize({ width: 1280, height: 800 });
+      await page.emulateMedia({ colorScheme: 'light' });
+      await page.goto(Route.Home);
+
+      const primaryCta = page
+        .locator('a.cta-primary, button.cta-primary')
+        .first();
+      await expect(primaryCta).toBeVisible();
+
+      await primaryCta.hover();
+
+      const afterStyles = await primaryCta.evaluate((el) => {
+        const pseudo = window.getComputedStyle(el, '::after');
+        return {
+          animationName: pseudo.animationName,
+          opacity: Number(pseudo.opacity),
+        };
+      });
+
+      expect(afterStyles.animationName).toContain('cta-shimmer');
+      expect(afterStyles.opacity).toBeGreaterThan(0);
+    });
+
+    test('should disable CTA shimmer when reduced motion is enabled', async ({
+      page,
+    }) => {
+      await page.setViewportSize({ width: 1280, height: 800 });
+      await page.emulateMedia({
+        colorScheme: 'light',
+        reducedMotion: 'reduce',
+      });
+      await page.goto(Route.Home);
+
+      const primaryCta = page
+        .locator('a.cta-primary, button.cta-primary')
+        .first();
+      await expect(primaryCta).toBeVisible();
+
+      await primaryCta.hover();
+
+      const animationName = await primaryCta.evaluate(
+        (el) => window.getComputedStyle(el, '::after').animationName
+      );
+
+      expect(animationName).toBe('none');
+    });
+  });
+
   test.describe('Persistence', () => {
     test('should save theme preference to localStorage', async ({ page }) => {
       await page.emulateMedia({ colorScheme: 'dark' });


### PR DESCRIPTION
## Summary
- Ensure primary green CTA buttons render white text in light theme for stronger contrast and visual polish.
- Add a subtle shimmer hover/focus treatment to primary CTA buttons across shared CTA patterns.
- Respect `prefers-reduced-motion` by disabling shimmer animation when reduced motion is requested.

Closes #29

## Changes
- Added reusable `.cta-primary` shimmer styling and keyframes in `src/styles/global.css` with reduced-motion safeguards.
- Applied `.cta-primary` to primary CTA usage in `src/components/layout/Header.astro`, `src/components/sections/CTASection.astro`, and `src/components/ui/Button.tsx`.
- Added E2E coverage in `tests/theme.spec.ts` for light-theme CTA text color, shimmer-on-hover behavior, and reduced-motion behavior.

## Test Plan
- [x] `npm run lint` passes
- [x] `npm run format:check` passes
- [x] `npm run build` succeeds
- [x] `npm run test` passes
- [x] Manual verification in browser for CTA hover/focus behavior

## Screenshots (if applicable)
- N/A (styling refinement covered by E2E assertions)

---
Generated with OpenCode