### PR TITLE
fix(ci): reduce e2e browser matrix and harden theme tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,8 +58,8 @@ jobs:
 
       - name: Run Playwright tests (Chromium)
         if: github.event_name == 'pull_request' && github.event.pull_request.draft != true
-        run: npx playwright test --project=chromium
+        run: npm run test:local
 
       - name: Run Playwright tests (all browsers)
         if: github.event_name == 'push'
-        run: npx playwright test
+        run: npm run test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ npm run lint && npm run format:check && npm run build
 
 ### Before Opening a PR
 
-Local (Chromium only) E2E tests must pass before opening a pull request:
+Local (Desktop Chrome only) E2E tests must pass before opening a pull request:
 
 ```bash
 npm run test:local
@@ -58,7 +58,7 @@ npm run test:local
 
 ### When a PR is Already Open
 
-If a PR is already open for the current branch, Local (Chromium only) E2E tests must pass before committing additional changes:
+If a PR is already open for the current branch, Local (Desktop Chrome only) E2E tests must pass before committing additional changes:
 
 ```bash
 npm run test:local
@@ -322,13 +322,13 @@ E2E tests in `tests/` directory:
 
 CI runs different levels of E2E testing based on PR state:
 
-| Tier             | Trigger                    | What runs                      | ~Time  |
-| ---------------- | -------------------------- | ------------------------------ | ------ |
-| **Draft PR**     | `pull_request` (draft)     | Lint + format + typecheck only | ~1 min |
-| **Ready PR**     | `pull_request` (not draft) | Above + E2E on Chromium only   | ~3 min |
-| **Push to main** | `push` (after merge)       | Above + E2E on all 4 browsers  | ~7 min |
+| Tier             | Trigger                    | What runs                                     | ~Time  |
+| ---------------- | -------------------------- | --------------------------------------------- | ------ |
+| **Draft PR**     | `pull_request` (draft)     | Lint + format + typecheck only                | ~1 min |
+| **Ready PR**     | `pull_request` (not draft) | Above + E2E on Desktop Chrome only            | ~3 min |
+| **Push to main** | `push` (after merge)       | Above + E2E on Desktop Chrome + Mobile Safari | ~5 min |
 
-The pre-push hook (`.husky/pre-push`) also runs Chromium-only E2E tests locally before push.
+The pre-push hook (`.husky/pre-push`) also runs Desktop Chrome-only E2E tests locally before push.
 
 ## Known Constraints
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "typecheck": "astro check",
     "test": "playwright test",
     "test:ui": "playwright test --ui",
-    "test:local": "playwright test --project=chromium",
+    "test:local": "playwright test --project=\"Desktop Chrome\"",
     "prepare": "husky"
   },
   "dependencies": {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -18,16 +18,8 @@ export default defineConfig({
   },
   projects: [
     {
-      name: 'chromium',
+      name: 'Desktop Chrome',
       use: { ...devices['Desktop Chrome'] },
-    },
-    {
-      name: 'webkit',
-      use: { ...devices['Desktop Safari'] },
-    },
-    {
-      name: 'Mobile Chrome',
-      use: { ...devices['Pixel 7'] },
     },
     {
       name: 'Mobile Safari',


### PR DESCRIPTION
## Summary
- reduce the Playwright project matrix to Desktop Chrome and Mobile Safari for the full suite, and align local script/project names
- update CI to run Playwright through npm scripts (`npm run test:local` on PRs, `npm run test` on push)
- harden `tests/theme.spec.ts` by making hover shimmer assertions device-capability aware and replacing timing-sensitive checks with more robust waits
- update testing strategy docs in `CLAUDE.md` to reflect the new browser coverage and expected runtime

## Verification
- npm run test