### PR TITLE
fix(seo): tighten home meta descriptions and blend authority links

### DIFF
--- a/src/components/sections/HeroSection.astro
+++ b/src/components/sections/HeroSection.astro
@@ -57,10 +57,36 @@ const servicesHref = getLocalizedPath(lang, Route.Services);
 
       <!-- Description -->
       <p
-        class="animate-fade-in-up text-foreground-subtle mx-auto mt-4 max-w-md text-base"
+        class="animate-fade-in-up text-foreground-subtle mx-auto mt-4 max-w-2xl text-base"
         style="animation-delay: 0.3s;"
       >
         {t.hero.subtitle}
+        {' '}
+        {t.hero.referencesPrefix}{' '}
+        <a
+          href="https://dora.dev/"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="text-foreground hover:text-primary underline underline-offset-4"
+        >
+          {t.hero.referenceDora}</a
+        >{t.hero.referencesSeparator}{' '}
+        <a
+          href="https://owasp.org/www-project-top-ten/"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="text-foreground hover:text-primary underline underline-offset-4"
+        >
+          {t.hero.referenceOwasp}</a
+        >{t.hero.referencesBeforeLast}{' '}
+        <a
+          href="https://developers.openai.com/codex/guides/build-ai-native-engineering-team"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="text-foreground hover:text-primary underline underline-offset-4"
+        >
+          {t.hero.referenceAgents}</a
+        >.
       </p>
 
       <!-- CTAs -->

--- a/src/features/i18n/i18n.translations.ts
+++ b/src/features/i18n/i18n.translations.ts
@@ -53,6 +53,12 @@ export interface TranslationStrings {
     experience: string;
     startupsScaleups: string;
     remoteFirst: string;
+    referencesPrefix: string;
+    referencesSeparator: string;
+    referencesBeforeLast: string;
+    referenceDora: string;
+    referenceOwasp: string;
+    referenceAgents: string;
   };
   // Services section
   services: {
@@ -201,7 +207,7 @@ export interface TranslationStrings {
   };
   // SEO-specific metadata (decoupled from visible UI text)
   seo: {
-    home: { ogTitle: string; ogDescription: string };
+    home: { metaDescription: string; ogTitle: string; ogDescription: string };
     about: { ogTitle: string; ogDescription: string };
     services: { ogTitle: string; ogDescription: string };
     contact: { ogTitle: string; ogDescription: string };
@@ -237,6 +243,12 @@ export const translations: Record<Language, TranslationStrings> = {
       experience: 'Hands-on engineering leadership',
       startupsScaleups: 'Seed to Series A',
       remoteFirst: 'AI-augmented development',
+      referencesPrefix: 'I align delivery with proven frameworks like',
+      referencesSeparator: ',',
+      referencesBeforeLast: ', and',
+      referenceDora: 'DORA',
+      referenceOwasp: 'OWASP Top 10',
+      referenceAgents: 'Building an AI-Native Engineering Team',
     },
     services: {
       title: 'Services',
@@ -508,6 +520,8 @@ export const translations: Record<Language, TranslationStrings> = {
     },
     seo: {
       home: {
+        metaDescription:
+          'Fractional CTO and technical consulting for early-stage startups. Architecture, AI workflows, and engineering teams from seed to Series A.',
         ogTitle:
           'Jerna Digital \u2014 AI-First Technical Leadership for Startups',
         ogDescription:
@@ -566,6 +580,12 @@ export const translations: Record<Language, TranslationStrings> = {
       experience: 'Liderazgo de ingenier\u00EDa hands-on',
       startupsScaleups: 'De Seed a Serie A',
       remoteFirst: 'Desarrollo potenciado por IA',
+      referencesPrefix: 'Trabajo con marcos probados como',
+      referencesSeparator: ',',
+      referencesBeforeLast: ' y',
+      referenceDora: 'DORA',
+      referenceOwasp: 'OWASP Top 10',
+      referenceAgents: 'Building an AI-Native Engineering Team',
     },
     services: {
       title: 'Servicios',
@@ -841,6 +861,8 @@ export const translations: Record<Language, TranslationStrings> = {
     },
     seo: {
       home: {
+        metaDescription:
+          'CTO fraccional y consultoría técnica para startups en fase inicial: arquitectura, IA y equipos de ingeniería desde seed hasta Serie A.',
         ogTitle:
           'Jerna Digital \u2014 Liderazgo T\u00E9cnico AI-First para Startups',
         ogDescription:

--- a/src/pages/[...lang]/index.astro
+++ b/src/pages/[...lang]/index.astro
@@ -31,7 +31,7 @@ const t = getTranslations(lang);
 <BaseLayout
   lang={lang}
   title={t.site.name}
-  description={t.site.description}
+  description={t.seo.home.metaDescription}
   ogTitle={t.seo.home.ogTitle}
   ogDescription={t.seo.home.ogDescription}
 >

--- a/tests/seo.spec.ts
+++ b/tests/seo.spec.ts
@@ -1,6 +1,12 @@
 import { test, expect } from '@playwright/test';
 import { Route, spanishPath } from './utils/routes';
 
+const expectedHomeReferenceLinks = [
+  'https://dora.dev/',
+  'https://owasp.org/www-project-top-ten/',
+  'https://developers.openai.com/codex/guides/build-ai-native-engineering-team',
+];
+
 function readPngDimensions(data: Buffer): { width: number; height: number } {
   const pngSignature = [137, 80, 78, 71, 13, 10, 26, 10];
 
@@ -145,6 +151,36 @@ test.describe('SEO', () => {
   });
 
   test.describe('i18n SEO', () => {
+    test('home meta description should be 150 chars or fewer in both locales', async ({
+      page,
+    }) => {
+      const homePaths = [Route.Home, spanishPath(Route.Home)];
+
+      for (const path of homePaths) {
+        await page.goto(path);
+        const description = await page
+          .locator('meta[name="description"]')
+          .getAttribute('content');
+
+        expect(description).toBeTruthy();
+        expect(description!.length).toBeLessThanOrEqual(150);
+      }
+    });
+
+    test('home should include authoritative external reference links', async ({
+      page,
+    }) => {
+      const homePaths = [Route.Home, spanishPath(Route.Home)];
+
+      for (const path of homePaths) {
+        await page.goto(path);
+
+        for (const href of expectedHomeReferenceLinks) {
+          await expect(page.locator(`a[href="${href}"]`).first()).toBeVisible();
+        }
+      }
+    });
+
     test('should have hreflang tags on English pages', async ({ page }) => {
       await page.goto(Route.Home);
 


### PR DESCRIPTION
## Summary
- Add dedicated localized home `seo.home.metaDescription` values and wire the home page to use them so EN/ES meta descriptions stay within 150 characters.
- Blend authoritative external references into existing hero copy (DORA, OWASP Top 10, and OpenAI's *Building an AI-Native Engineering Team*) instead of a standalone references line.
- Extend SEO Playwright coverage to assert home meta length limits in both locales and verify required external reference links.

## Validation
- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npm run build`
- `npm run test -- tests/seo.spec.ts`
- `npm run test:local` (triggered by git push hook)

Closes #47