### PR TITLE
chore(deps): constrain unsupported major updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,8 @@ updates:
         versions: ['>=10']
       - dependency-name: '@eslint/js'
         versions: ['>=10']
+      - dependency-name: 'eslint-plugin-astro'
+        versions: ['>=2']
       # typescript-eslint currently supports TypeScript versions below 6.1.
       - dependency-name: 'typescript'
         versions: ['>=7']

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,15 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+    ignore:
+      # Current lint plugins do not yet support ESLint 10.
+      - dependency-name: 'eslint'
+        versions: ['>=10']
+      - dependency-name: '@eslint/js'
+        versions: ['>=10']
+      # typescript-eslint currently supports TypeScript versions below 6.1.
+      - dependency-name: 'typescript'
+        versions: ['>=7']
     groups:
       npm-dependencies:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,8 @@ updates:
     schedule:
       interval: 'weekly'
     ignore:
-      # Current lint plugins do not yet support ESLint 10.
+      # eslint-plugin-jsx-a11y supports ESLint through 9; remove these ignores
+      # once it supports ESLint 10 and the lint stack can be upgraded together.
       - dependency-name: 'eslint'
         versions: ['>=10']
       - dependency-name: '@eslint/js'
@@ -19,7 +20,7 @@ updates:
         versions: ['>=2']
       # typescript-eslint currently supports TypeScript versions below 6.1.
       - dependency-name: 'typescript'
-        versions: ['>=7']
+        versions: ['>=6.1.0']
     groups:
       npm-dependencies:
         patterns:


### PR DESCRIPTION
## Summary
- prevent Dependabot from recreating ESLint 10 updates while eslint-plugin-jsx-a11y supports only ESLint through 9
- defer eslint-plugin-astro 2+ because those releases require ESLint 10
- prevent TypeScript 7 updates while typescript-eslint supports versions below 6.1
- retain all compatible weekly npm and GitHub Actions updates

## Validation
- npm run lint
- npm run format:check
- npm run typecheck
- npm run build
- npm run test:local (146 passed)